### PR TITLE
feat: Define dedicated title for all pages

### DIFF
--- a/public/components/Blog/index.js
+++ b/public/components/Blog/index.js
@@ -4,6 +4,8 @@ import config from '../../config.json';
 import styles from './style.module.scss';
 
 export default function Blog({ params = {}, count = config.postsPerPage, moreText = '' }) {
+	document.title = `Blog - ${config.title}`;
+
 	let { page = 0 } = params;
 	count = Math.min(posts.length, Math.max(0, Math.round(count || 5)));
 	page = Math.round(page || 0);

--- a/public/components/BlogPost/index.js
+++ b/public/components/BlogPost/index.js
@@ -1,8 +1,10 @@
 import { lazy } from 'preact-iso';
 // import posts from 'content:../../content/blog';
 import '../../styles/prism.css';
+import config from '../../config.json';
 
 function DisplayBlogPost({ html, meta }) {
+	document.title = `${meta.title} - ${config.title}`;
 	const pub = new Date(meta.published);
 	const [, month, day, year] = pub.toDateString().split(' ');
 	return (

--- a/public/components/Home/index.js
+++ b/public/components/Home/index.js
@@ -3,6 +3,8 @@ import config from '../../config.json';
 import styles from './style.module.scss';
 
 export default function Home() {
+	document.title = config.title;
+
 	if (typeof window === 'undefined') {
 		document.head.insertAdjacentHTML('beforeend', `<link rel="preload" as="image" href="${config.cover}">`);
 	}

--- a/public/components/NotFound/index.js
+++ b/public/components/NotFound/index.js
@@ -1,8 +1,14 @@
-const NotFound = () => (
-	<section class="content">
-		<h1>404: Not Found</h1>
-		<p>It's gone :(</p>
-	</section>
-);
+import config from '../../config.json';
+
+const NotFound = () => {
+	document.title = config.title;
+
+	return (
+		<section className="content">
+			<h1>404: Not Found</h1>
+			<p>It's gone :(</p>
+		</section>
+	);
+}
 
 export default NotFound;


### PR DESCRIPTION
When reading your blog, it is hard to switch from on tab to another one, because we have the same title for every pages. 
With the PR, I prefix the default title with the name of the blog post. 